### PR TITLE
Add multi-queue support and exponential backoff for full queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ QuasiQueue is a MultiProcessing library for Python that makes it super easy to h
 
 QuasiQueue works by splitting the work into two components- the main process whose job it is to feed a Queue with work, and then read processes that take work off of the Queue to run. All the developers have to do is create two functions-
 
-* `writer` is called when the queue gets low. It should return an iterable (list, generator) that QuasiQueue uses to grow the multiprocess Queue.
-* `reader` is called once for each item in the Queue. It runs in completely different processes from the `writer`.
+- `writer` is called when the queue gets low. It should return an iterable (list, generator) that QuasiQueue uses to grow the multiprocess Queue.
+- `reader` is called once for each item in the Queue. It runs in completely different processes from the `writer`.
 
 ```mermaid
 flowchart LR
@@ -76,7 +76,6 @@ flowchart LR
   end
 ```
 
-
 ### Website Image Crawler
 
 QuasiQueue could be used to crawl a website, or series of websites, to download data.
@@ -115,13 +114,11 @@ flowchart LR
   reader1(reader)-->ProcessedFiles
 ```
 
-
 ## Installation
 
 ```bash
 pip install quasiqueue
 ```
-
 
 ## Arguments
 
@@ -205,18 +202,20 @@ Although this function is not required it can have amazing performance implicati
 
 QuasiQueue has a variety of optimization settings that can be tweaked depending on usage.
 
-|            Name           |  Type |                                                   Description                                                 |Default|
-|---------------------------|-------|---------------------------------------------------------------------------------------------------------------|-------|
-|  `empty_queue_sleep_time` |  float| The time in seconds that QuasiQueue will sleep the writer process when it returns no results.                 |  1.0  |
-|  `full_queue_sleep_time`  |  float| The time in seconds that QuasiQueue will sleep the writer process if the queue is completely full.            |  5.0  |
-|`graceful_shutdown_timeout`|integer| The time in seconds that QuasiQueue will wait for readers to finish when it is asked to gracefully shutdown.  |   30  |
-|    `lookup_block_size`    |integer|The default desired passed to the writer function. This will be adjusted lower depending on queue dynamics.    |   10  |
-|   `max_jobs_per_process`  |integer| The number of jobs a reader process will run before it is replaced by a new process.                          |  200  |
-| `concurrent_tasks_per_process`  |integer| How many async tasks can run at once inside a single process.                                           |    2  |
-|      `max_queue_size`     |integer| The max allowed size of the queue.                                                                            |  300  |
-|      `num_processes`      |integer| The number of reader processes to run.                                                                        |    2  |
-|  `prevent_requeuing_time` |integer| The time in seconds that an item will be prevented from being readded to the queue.                           |  300  |
-|`queue_interaction_timeout`|  float| The time QuasiQueue will wait for the Queue to be unlocked before throwing an error.                          | 0.01  |
+| Name                           | Type    | Description                                                                                                  | Default |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------ | ------- |
+| `empty_queue_sleep_time`       | float   | The time in seconds that QuasiQueue will sleep the writer process when it returns no results.                | 1.0     |
+| `full_queue_sleep_time`        | float   | Legacy. Use `full_queue_sleep_min` and `full_queue_sleep_max` instead.                                       | 5.0     |
+| `full_queue_sleep_min`         | float   | Minimum seconds to sleep after a full-queue failure (exponential backoff starts here).                       | 1.0     |
+| `full_queue_sleep_max`         | float   | Maximum seconds to sleep after consecutive full-queue failures (backoff caps here).                          | 90.0    |
+| `graceful_shutdown_timeout`    | integer | The time in seconds that QuasiQueue will wait for readers to finish when it is asked to gracefully shutdown. | 30      |
+| `lookup_block_size`            | integer | The default desired passed to the writer function. This will be adjusted lower depending on queue dynamics.  | 10      |
+| `max_jobs_per_process`         | integer | The number of jobs a reader process will run before it is replaced by a new process.                         | 200     |
+| `concurrent_tasks_per_process` | integer | How many async tasks can run at once inside a single process.                                                | 4       |
+| `max_queue_size`               | integer | The max allowed size of the queue.                                                                           | 300     |
+| `num_processes`                | integer | The number of reader processes to run.                                                                       | 2       |
+| `prevent_requeuing_time`       | integer | The time in seconds that an item will be prevented from being readded to the queue.                          | 300     |
+| `queue_interaction_timeout`    | float   | The time QuasiQueue will wait for the Queue to be unlocked before throwing an error.                         | 0.01    |
 
 Settings can be configured programmatically, via environment variables, or both.
 
@@ -243,7 +242,6 @@ QuasiQueue(
 
 This method is simple, but the downside is that you lose the environment variable prefixes. So when using this method you have to set `NUM_PROCESSES` rather than `MYQUEUE_NUM_PROCESSES`. The work around is to extend the Settings object to give it your desired prefix.
 
-
 ```python
 from quasiqueue import Settings, QuasiQueue
 from pydantic_settings import SettingsConfigDict
@@ -259,6 +257,69 @@ QuasiQueue(
   settings=MySettings()
 )
 ```
+
+#### Advanced: Multiple Queues
+
+You can run multiple queues concurrently in a single process using `run_queues()`. Each queue has its own writer, reader, and worker processes, but they share a single signal handler for coordinated shutdown.
+
+```python
+import asyncio
+
+from quasiqueue import QuasiQueue, run_queues
+
+
+async def image_writer(desired: int):
+  for i in range(desired):
+    yield f"image_{i}"
+
+async def audio_writer(desired: int):
+  for i in range(desired):
+    yield f"audio_{i}"
+
+async def process_image(item: int | str):
+  print(f"Processing image: {item}")
+
+async def process_audio(item: int | str):
+  print(f"Processing audio: {item}")
+
+runner_a = QuasiQueue("images", reader=process_image, writer=image_writer)
+runner_b = QuasiQueue("audio",  reader=process_audio,  writer=audio_writer)
+
+if __name__ == '__main__':
+  run_queues(runner_a, runner_b)
+```
+
+When `run_queues()` is called, both queues run in the same event loop. If the process receives a `SIGINT` or `SIGTERM`, both queues shut down together.
+
+#### Advanced: Custom Event Loop
+
+For more control, you can use `_run_loop()` directly with your own event loop:
+
+```python
+import asyncio
+import multiprocessing as mp
+
+from quasiqueue import QuasiQueue
+
+runner_a = QuasiQueue("images", reader=process_image, writer=image_writer)
+runner_b = QuasiQueue("audio",  reader=process_audio,  writer=audio_writer)
+
+ctx = mp.get_context("fork")
+shutdown_event = ctx.Event()
+runner_a.setup_signals(shutdown_event)
+
+async def custom_loop():
+  await asyncio.gather(
+    runner_a._run_loop(shutdown_event),
+    runner_b._run_loop(shutdown_event),
+  )
+
+asyncio.run(custom_loop)
+```
+
+#### Advanced: Builder and reader_process
+
+`Builder` and `reader_process` are exported for custom orchestration outside of `QueueRunner`.
 
 ### Accessing Settings
 

--- a/quasiqueue/__init__.py
+++ b/quasiqueue/__init__.py
@@ -2,8 +2,19 @@ try:
     from . import _version  # type: ignore
 
     __version__ = _version.__version__
-except:  # noqa: E722
+except Exception:
     __version__ = "0.0.0-dev"
 
+from .builder import Builder  # noqa: F401
+from .reader import reader_process  # noqa: F401
 from .runner import QueueRunner as QuasiQueue  # noqa: F401
+from .runner import run_queues  # noqa: F401
 from .settings import Settings  # noqa: F401
+
+__all__ = [
+    "Builder",
+    "QuasiQueue",
+    "Settings",
+    "reader_process",
+    "run_queues",
+]

--- a/quasiqueue/builder.py
+++ b/quasiqueue/builder.py
@@ -14,6 +14,9 @@ class Builder:
         self.last_queued = {}
         self.writer = writer
         self.closed = False
+        self.exhausted = False
+        self.empty_count = 0
+        self.full_consecutive = 0
         self.writer_args = inspect.getfullargspec(self.writer).args
 
     async def populate(self, max=50):
@@ -24,12 +27,15 @@ class Builder:
         if "settings" in self.writer_args:
             writer_kw_args["settings"] = self.settings
 
-        # Writers can be expensive but cheaper when pulling bulk records.
-        queue_size = self.queue.qsize()
+        try:
+            queue_size = self.queue.qsize()
+        except NotImplementedError:
+            queue_size = 0
         if queue_size >= self.settings.max_queue_size * 0.3:
+            self.empty_count = 0
+            self.full_consecutive = 0
             return True
 
-        # Don't try to fill the queue 100% since the queue size isn't always accurate.
         count = min(int(self.settings.max_queue_size * 0.8) - queue_size, max)
         blocksize = min(self.settings.lookup_block_size, count)
 
@@ -38,11 +44,11 @@ class Builder:
 
         if count <= 0:
             logger.debug("Skipping queue population due to max queue size.")
+            self.full_consecutive += 1
             return False
         try:
             successful_adds = 0
 
-            # If the queue is closed tell the children processes to close.
             if self.closed:
                 for i in range(0, blocksize):
                     self.queue.put("close", True, self.settings.queue_interaction_timeout)
@@ -51,14 +57,30 @@ class Builder:
             async for id in self.writer(**writer_kw_args):
                 if id is None or id is False:
                     logger.debug(f"Returning False {id}")
+                    self.empty_count += 1
+                    self.full_consecutive += 1
+                    if self.empty_count >= self.settings.empty_queue_sleep_time:
+                        self.exhausted = True
                     return False
                 if self.add_to_queue(id):
                     logger.debug(f"Added {id} to queue.")
                     successful_adds += 1
+                    self.empty_count = 0
+                    self.full_consecutive = 0
                     if successful_adds >= max:
                         return True
+
+            if successful_adds == 0:
+                self.empty_count += 1
+                self.full_consecutive += 1
+                if self.empty_count >= self.settings.empty_queue_sleep_time:
+                    self.exhausted = True
+                return False
+
+            return True
         except Full:
             logger.debug("Queue has reached max size.")
+            self.full_consecutive += 1
             return False
 
     def add_to_queue(self, id):
@@ -74,12 +96,23 @@ class Builder:
 
     def clean_history(self):
         self.last_queued = {
-            # Keep item as long as that item expires in the future. Items which have already expired will be removed.
-            k: v
-            for k, v in self.last_queued.items()
-            if v + self.settings.prevent_requeuing_time > time.time()
+            k: v for k, v in self.last_queued.items() if v + self.settings.prevent_requeuing_time > time.time()
         }
 
     def close(self):
-        if self.closed:
-            return False
+        self.closed = True
+        blocksize = self.settings.lookup_block_size
+        for _ in range(0, blocksize):
+            try:
+                self.queue.put("close", True, self.settings.queue_interaction_timeout)
+            except Full:
+                break
+        return True
+
+    def full_queue_sleep_time(self) -> float:
+        if self.full_consecutive == 0:
+            return self.settings.full_queue_sleep_min
+        return min(
+            self.settings.full_queue_sleep_min * (2 ** (self.full_consecutive - 1)),
+            self.settings.full_queue_sleep_max,
+        )

--- a/quasiqueue/runner.py
+++ b/quasiqueue/runner.py
@@ -41,54 +41,56 @@ class QueueRunner(object):
         self.context = context
         self.worker_launches = 0
 
-    async def main(self) -> None:
-        """Run the parent process that supervises workers and queue population."""
-        # Use fork explicitly so that worker callables (including locally-defined
-        # functions) do not need to be picklable. Python 3.14 changed the default
-        # start method on Linux to forkserver, which requires pickling all process
-        # arguments; fork inherits the parent's address space and avoids that.
-        ctx = mp.get_context("fork")
-        import_queue: mp.Queue = ctx.Queue(self.settings.max_queue_size)
-        queue_builder = Builder(import_queue, self.settings, self.writer)
-        shutdown_event = ctx.Event()
+    def setup_signals(self, shutdown_event: mp.synchronize.Event) -> None:
+        """Register signal handlers on the given event.
+
+        Safe to call multiple times — each call attaches the same handler
+        logic to the same event, so multiple QueueRunners can share a
+        single shutdown_event for coordinated teardown.
+
+        Args:
+            shutdown_event: A multiprocessing Event that will be set when
+                SIGINT or SIGTERM is received.
+        """
 
         def shutdown(a=None, b=None):
-            # Inline function to implicitly pass through shutdown_event.
             if a is not None:
-                logger.debug(f"Signal {a} caught.")
+                logger.debug(f"[{self.name}] Signal {a} caught.")
 
-            # Send shutdown signal to all processes.
             shutdown_event.set()
 
-            # Graceful shutdown- wait for children to shut down.
             if a == 15 or a is None:
                 logger.debug("Gracefully shutting down child processes.")
-                logger.debug(self.settings.graceful_shutdown_timeout)
                 shutdown_start = time.time()
                 while len(psutil.Process().children()) > 0:
                     if time.time() > (shutdown_start + self.settings.graceful_shutdown_timeout):
                         break
                     time.sleep(0.05)
 
-            # Kill any remaining processes directly, not counting on variables.
             remaining_processes = psutil.Process().children()
             if len(remaining_processes) > 0:
                 logger.debug("Terminating remaining child processes.")
                 for process in remaining_processes:
                     process.terminate()
 
-        # Set shutdown function as signal handler for SIGINT and SIGTERM.
         signal.signal(signal.SIGINT, shutdown)
         signal.signal(signal.SIGTERM, shutdown)
 
+    async def _run_loop(self, shutdown_event: mp.synchronize.Event) -> None:
+        """Per-queue async loop: spawn workers, populate queue, prune dead processes.
+
+        Args:
+            shutdown_event: Event that signals the loop to exit.
+        """
+        ctx = mp.get_context("fork")
+        import_queue: mp.Queue = ctx.Queue(self.settings.max_queue_size)
+        queue_builder = Builder(import_queue, self.settings, self.writer)
+
         try:
-            # Now start actual script.
             processes: List[mp.process.BaseProcess] = []
             while not shutdown_event.is_set():
-                # Prune dead processes
                 processes = [x for x in processes if x.is_alive()]
 
-                # Bring process list up to size
                 new_processes = 0
                 while len(processes) < self.settings.num_processes:
                     process = self.launch_process(import_queue, shutdown_event)
@@ -97,27 +99,32 @@ class QueueRunner(object):
                     new_processes += 1
 
                 if new_processes:
-                    # Give newly-started workers time to initialize and begin
-                    # blocking on queue.get() before we fill the queue, so that
-                    # items are distributed fairly across all workers rather than
-                    # being consumed entirely by whichever process starts first.
                     await asyncio.sleep(0.1)
 
-                # Populate Queue
                 if not await queue_builder.populate():
-                    logger.debug("Queue unable to populate: sleeping scheduler.")
-                    await asyncio.sleep(self.settings.full_queue_sleep_time)
+                    logger.debug(f"[{self.name}] Queue unable to populate: sleeping scheduler.")
+                    await asyncio.sleep(queue_builder.full_queue_sleep_time())
                 else:
-                    # Small sleep between populate attempts to prevent CPU/database pegging.
                     await asyncio.sleep(0.05)
         finally:
-            logger.warning("Shutting down all processes.")
-            shutdown()
-            # Explicitly close the queue now that the parent owns its
-            # lifecycle directly instead of delegating it to a Manager.
+            logger.warning(f"[{self.name}] Shutting down all processes.")
             import_queue.close()
             import_queue.join_thread()
-            logger.warning("All processes shut down.")
+            logger.warning(f"[{self.name}] All processes shut down.")
+
+    async def main(self) -> None:
+        """Run the parent process that supervises workers and queue population.
+
+        Backward-compatible entry point — sets up signals and runs the loop.
+        """
+        ctx = mp.get_context("fork")
+        shutdown_event = ctx.Event()
+        self.setup_signals(shutdown_event)
+
+        try:
+            await self._run_loop(shutdown_event)
+        finally:
+            shutdown_event.set()
 
     def launch_process(self, import_queue, shutdown_event) -> mp.process.BaseProcess:
         """Create one worker process with the queue contract it will consume."""
@@ -137,3 +144,26 @@ class QueueRunner(object):
         logger.debug(f"Launching worker {process.name}")
         process.daemon = True
         return process
+
+
+def run_queues(*runners: QueueRunner) -> None:
+    """Run multiple QueueRunner instances in a single event loop.
+
+    All runners share a single shutdown event and signal handler. When
+    SIGINT or SIGTERM is received, every queue loop exits together.
+
+    Args:
+        *runners: Two or more QueueRunner instances to run concurrently.
+    """
+    ctx = mp.get_context("fork")
+    shutdown_event = ctx.Event()
+
+    runners[0].setup_signals(shutdown_event)
+
+    async def _run_all():
+        try:
+            await asyncio.gather(*[runner._run_loop(shutdown_event) for runner in runners])
+        finally:
+            shutdown_event.set()
+
+    asyncio.run(_run_all())

--- a/quasiqueue/settings.py
+++ b/quasiqueue/settings.py
@@ -17,7 +17,15 @@ class Settings(BaseSettings):
     )
     full_queue_sleep_time: float = Field(
         default=5.00,
-        description="The time in seconds that QuasiQueue will sleep the writer process if the queue is completely full.",
+        description="Legacy. Use full_queue_sleep_min and full_queue_sleep_max instead.",
+    )
+    full_queue_sleep_min: float = Field(
+        default=1.0,
+        description="Minimum seconds to sleep after a full-queue failure (backoff starts here).",
+    )
+    full_queue_sleep_max: float = Field(
+        default=90.0,
+        description="Maximum seconds to sleep after consecutive full-queue failures.",
     )
     queue_interaction_timeout: float = Field(
         default=0.01,

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,60 @@
+import multiprocessing as mp
+
+from quasiqueue import Builder, Settings
+
+
+def make_builder(max_size=100, **kwargs):
+    ctx = mp.get_context("fork")
+    queue = ctx.Queue(max_size)
+    settings = Settings(**kwargs)
+    return Builder(queue, settings, lambda: iter([]))
+
+
+def test_backoff_progression():
+    b = make_builder()
+    b.full_consecutive = 0
+
+    for i in range(1, 8):
+        b.full_consecutive = i
+        expected = min(1.0 * (2 ** (i - 1)), 90.0)
+        assert (
+            b.full_queue_sleep_time() == expected
+        ), f"consecutive={i}, expected={expected}, got={b.full_queue_sleep_time()}"
+
+
+def test_backoff_reset_on_zero():
+    b = make_builder()
+    b.full_consecutive = 5
+    b.full_consecutive = 0
+    assert b.full_queue_sleep_time() == 1.0
+
+
+def test_backoff_cap():
+    b = make_builder()
+    b.full_consecutive = 10
+    assert b.full_queue_sleep_time() == 90.0
+
+    b.full_consecutive = 20
+    assert b.full_queue_sleep_time() == 90.0
+
+
+def test_backoff_custom_min_max():
+    settings = Settings(full_queue_sleep_min=0.5, full_queue_sleep_max=10.0)
+    ctx = mp.get_context("fork")
+    queue = ctx.Queue(100)
+    b = Builder(queue, settings, lambda: iter([]))
+
+    b.full_consecutive = 1
+    assert b.full_queue_sleep_time() == 0.5
+
+    b.full_consecutive = 2
+    assert b.full_queue_sleep_time() == 1.0
+
+    b.full_consecutive = 3
+    assert b.full_queue_sleep_time() == 2.0
+
+    b.full_consecutive = 5
+    assert b.full_queue_sleep_time() == 8.0
+
+    b.full_consecutive = 10
+    assert b.full_queue_sleep_time() == 10.0

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -17,9 +17,9 @@ def test_backoff_progression():
     for i in range(1, 8):
         b.full_consecutive = i
         expected = min(1.0 * (2 ** (i - 1)), 90.0)
-        assert (
-            b.full_queue_sleep_time() == expected
-        ), f"consecutive={i}, expected={expected}, got={b.full_queue_sleep_time()}"
+        assert b.full_queue_sleep_time() == expected, (
+            f"consecutive={i}, expected={expected}, got={b.full_queue_sleep_time()}"
+        )
 
 
 def test_backoff_reset_on_zero():

--- a/tests/test_multi_queue.py
+++ b/tests/test_multi_queue.py
@@ -1,0 +1,375 @@
+import asyncio
+import json
+import multiprocessing as mp
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from quasiqueue import Builder
+from quasiqueue.runner import QueueRunner
+from quasiqueue.settings import Settings
+
+
+class QuickTestSettings(Settings):
+    graceful_shutdown_timeout: float = 0.2
+    empty_queue_sleep_time: float = 0.05
+    save_dir: str
+
+
+class StopTestException(Exception):
+    pass
+
+
+# 4.1 Test: multi-queue concurrent execution
+def test_multi_queue_concurrent():
+    """Launch two QueueRunner instances via run_queues() with distinct writers/readers.
+    Verify items flow to correct readers without cross-contamination.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        dir_a = Path(d) / "a"
+        dir_b = Path(d) / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        script = f"""
+import asyncio
+from quasiqueue.runner import QueueRunner, run_queues
+from quasiqueue.settings import Settings
+
+class TestSettings(Settings):
+    graceful_shutdown_timeout: float = 0.5
+    empty_queue_sleep_time: float = 0.05
+    num_processes: int = 2
+    save_dir: str = ""
+
+import json
+from pathlib import Path
+
+settings_a = TestSettings(save_dir=r"{dir_a}")
+settings_b = TestSettings(save_dir=r"{dir_b}")
+
+async def writer_a(desired, settings):
+    for i in range(10):
+        yield f"a_{{i}}"
+    await asyncio.sleep(1)
+    raise StopIteration("done")
+
+async def writer_b(desired, settings):
+    for i in range(10):
+        yield f"b_{{i}}"
+    await asyncio.sleep(1)
+    raise StopIteration("done")
+
+async def reader_a(item, settings):
+    import json
+    from pathlib import Path
+    with open(Path(settings["save_dir"]) / f"{{item}}.output", "w") as f:
+        json.dump({{"item": item, "queue": "a"}}, f)
+
+async def reader_b(item, settings):
+    import json
+    from pathlib import Path
+    with open(Path(settings["save_dir"]) / f"{{item}}.output", "w") as f:
+        json.dump({{"item": item, "queue": "b"}}, f)
+
+runner_a = QueueRunner(name="queue_a", reader=reader_a, writer=writer_a, settings=settings_a)
+runner_b = QueueRunner(name="queue_b", reader=reader_b, writer=writer_b, settings=settings_b)
+
+try:
+    run_queues(runner_a, runner_b)
+except:
+    pass
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        files_a = list(dir_a.glob("*.output"))
+        files_b = list(dir_b.glob("*.output"))
+
+        assert len(files_a) > 0, f"Queue A should have processed items; stderr: {result.stderr}"
+        assert len(files_b) > 0, f"Queue B should have processed items; stderr: {result.stderr}"
+
+        # Verify no cross-contamination
+        for f in files_a:
+            data = json.load(open(f))
+            assert data["item"].startswith("a_"), f"Queue A got wrong item: {data['item']}"
+            assert data["queue"] == "a"
+
+        for f in files_b:
+            data = json.load(open(f))
+            assert data["item"].startswith("b_"), f"Queue B got wrong item: {data['item']}"
+            assert data["queue"] == "b"
+
+
+# 4.2 Test: shared shutdown event
+@pytest.mark.asyncio
+async def test_shared_shutdown_event():
+    """Verify both queues stop when shutdown_event is set."""
+    with tempfile.TemporaryDirectory() as d:
+        dir_a = Path(d) / "a"
+        dir_b = Path(d) / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        settings_a = QuickTestSettings(save_dir=str(dir_a), num_processes=1)
+        settings_b = QuickTestSettings(save_dir=str(dir_b), num_processes=1)
+
+        async def writer_a(desired: int, settings: dict):
+            for i in range(5):
+                yield f"a_{i}"
+            await asyncio.sleep(10)
+
+        async def writer_b(desired: int, settings: dict):
+            for i in range(5):
+                yield f"b_{i}"
+            await asyncio.sleep(10)
+
+        async def reader_a(item: str | int, settings: dict):
+            with open(Path(settings["save_dir"]) / f"{item}.output", "w") as f:
+                json.dump({"item": item}, f)
+
+        async def reader_b(item: str | int, settings: dict):
+            with open(Path(settings["save_dir"]) / f"{item}.output", "w") as f:
+                json.dump({"item": item}, f)
+
+        runner_a = QueueRunner(
+            name="shutdown_a",
+            reader=reader_a,
+            writer=writer_a,
+            settings=settings_a,
+        )
+        runner_b = QueueRunner(
+            name="shutdown_b",
+            reader=reader_b,
+            writer=writer_b,
+            settings=settings_b,
+        )
+
+        ctx = mp.get_context("fork")
+        shutdown_event = ctx.Event()
+        runner_a.setup_signals(shutdown_event)
+
+        async def _run():
+            await asyncio.gather(
+                runner_a._run_loop(shutdown_event),
+                runner_b._run_loop(shutdown_event),
+            )
+
+        async def _trigger_shutdown():
+            await asyncio.sleep(1)
+            shutdown_event.set()
+
+        await asyncio.gather(_run(), _trigger_shutdown())
+
+        files_a = list(dir_a.glob("*.output"))
+        files_b = list(dir_b.glob("*.output"))
+        assert len(files_a) > 0, "Queue A should have processed some items"
+        assert len(files_b) > 0, "Queue B should have processed some items"
+
+
+# 4.3 Test: writer exhaustion detection
+@pytest.mark.asyncio
+async def test_writer_exhaustion():
+    """Writer yields fixed items then returns None repeatedly.
+    Verify Builder.exhausted becomes True after threshold.
+    """
+    ctx = mp.get_context("fork")
+    queue = ctx.Queue(100)
+    settings = Settings(max_queue_size=100, empty_queue_sleep_time=3)
+
+    yield_count = 0
+
+    async def exhausting_writer(desired: int):
+        nonlocal yield_count
+        if yield_count == 0:
+            yield_count = 1
+            for i in range(5):
+                yield i
+        else:
+            yield None
+
+    builder = Builder(queue, settings, exhausting_writer)
+
+    result = await builder.populate()
+    assert result is True
+    assert builder.exhausted is False
+
+    for _ in range(5):
+        await builder.populate()
+
+    assert builder.exhausted is True, "Builder should be exhausted after threshold"
+
+
+# 4.3b Test: intermittent writer does not trigger exhaustion
+@pytest.mark.asyncio
+async def test_intermittent_writer_not_exhausted():
+    """Writer yields, then None, then yields again. Should not trigger exhaustion."""
+    ctx = mp.get_context("fork")
+    queue = ctx.Queue(100)
+    settings = Settings(max_queue_size=100, empty_queue_sleep_time=3)
+
+    call_count = 0
+
+    async def intermittent_writer(desired: int):
+        nonlocal call_count
+        call_count += 1
+        if call_count % 2 == 1:
+            yield call_count
+        else:
+            yield None
+
+    builder = Builder(queue, settings, intermittent_writer)
+
+    for _ in range(6):
+        await builder.populate()
+
+    assert builder.exhausted is False, "Intermittent writer should not trigger exhaustion"
+
+
+# 4.4 Test: Builder.close() sentinel delivery
+@pytest.mark.asyncio
+async def test_builder_close_sentinel():
+    """Call close() on a builder, verify 'close' sentinels in queue."""
+    ctx = mp.get_context("fork")
+    queue = ctx.Queue(100)
+    settings = Settings(max_queue_size=100, lookup_block_size=10, queue_interaction_timeout=0.01)
+
+    async def dummy_writer():
+        yield 1
+
+    builder = Builder(queue, settings, dummy_writer)
+
+    await builder.populate()
+    result = builder.close()
+    assert result is True
+    assert builder.closed is True
+
+    # Allow feeder thread time to flush sentinels to the pipe
+    await asyncio.sleep(0.2)
+
+    items = []
+    import queue as qmod
+
+    while True:
+        try:
+            item = queue.get(False)
+            items.append(item)
+        except qmod.Empty:
+            break
+
+    assert "close" in items, f"Queue should contain 'close' sentinels after builder.close(), got: {items}"
+
+
+# 4.4b Test: Builder.close() with Full exception
+@pytest.mark.asyncio
+async def test_builder_close_full_queue():
+    """Queue at capacity — close() should not crash."""
+    ctx = mp.get_context("fork")
+    queue = ctx.Queue(3)
+    settings = Settings(max_queue_size=3, lookup_block_size=10, queue_interaction_timeout=0.01)
+
+    async def dummy_writer():
+        yield 1
+
+    builder = Builder(queue, settings, dummy_writer)
+
+    queue.put("x")
+    queue.put("y")
+    queue.put("z")
+
+    result = builder.close()
+    assert result is True
+    assert builder.closed is True
+
+
+# 4.5 Test: _run_loop() isolation
+@pytest.mark.asyncio
+async def test_run_loop_isolation():
+    """Call _run_loop() directly with manual shutdown_event."""
+    with tempfile.TemporaryDirectory() as d:
+        settings = QuickTestSettings(save_dir=d, num_processes=1)
+
+        async def writer(desired: int, settings: dict):
+            for i in range(3):
+                yield i
+            await asyncio.sleep(10)
+
+        async def reader(item: str | int, settings: dict):
+            with open(Path(settings["save_dir"]) / f"{item}.output", "w") as f:
+                json.dump({"item": item}, f)
+
+        runner = QueueRunner(
+            name="isolation_test",
+            reader=reader,
+            writer=writer,
+            settings=settings,
+        )
+
+        ctx = mp.get_context("fork")
+        shutdown_event = ctx.Event()
+
+        async def _trigger():
+            await asyncio.sleep(1)
+            shutdown_event.set()
+
+        await asyncio.gather(runner._run_loop(shutdown_event), _trigger())
+
+        files = list(Path(d).glob("*.output"))
+        assert len(files) > 0, "_run_loop should have processed items before shutdown"
+
+
+# 4.6 Test: run_queues() with a single runner
+def test_run_queues_single_runner():
+    """Verify run_queues() with one runner behaves like asyncio.run(runner.main())."""
+    with tempfile.TemporaryDirectory() as d:
+        script = f"""
+import asyncio
+from quasiqueue.runner import QueueRunner, run_queues
+from quasiqueue.settings import Settings
+
+class TestSettings(Settings):
+    graceful_shutdown_timeout: float = 0.3
+    empty_queue_sleep_time: float = 0.05
+    num_processes: int = 2
+    save_dir: str = ""
+
+import json
+from pathlib import Path
+
+settings = TestSettings(save_dir=r"{d}")
+
+async def writer(desired, settings):
+    for i in range(20):
+        yield i
+    await asyncio.sleep(0.5)
+    raise StopIteration("done")
+
+async def reader(item, settings):
+    import json
+    from pathlib import Path
+    with open(Path(settings["save_dir"]) / f"{{item}}.output", "w") as f:
+        json.dump({{"item": item}}, f)
+
+runner = QueueRunner(name="single_test", reader=reader, writer=writer, settings=settings)
+
+try:
+    run_queues(runner)
+except:
+    pass
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        files = list(Path(d).glob("*.output"))
+        assert len(files) > 0, f"Single runner via run_queues should process items; stderr: {result.stderr}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,6 +16,8 @@ class QuickTestSettings(Settings):
     # after startup (the runner waits 0.1 s for workers to initialize before
     # filling the queue, which would otherwise exceed the default 1 s backoff).
     empty_queue_sleep_time: float = 0.05
+    full_queue_sleep_min: float = 0.05
+    full_queue_sleep_max: float = 0.05
     save_dir: str
 
 


### PR DESCRIPTION
- Decompose QueueRunner.main() into setup_signals() and _run_loop()
- Add run_queues() for running multiple queues in a single event loop
- Add Builder, reader_process, run_queues to public exports
- Implement exponential backoff (full_queue_sleep_min/max) for full-queue conditions
- Add qsize() NotImplementedError fallback for macOS
- Add writer exhaustion detection with empty_count tracking
- Add 12 new tests (backoff + multi-queue)
- Update README.md and architecture docs

resolves #20 